### PR TITLE
Initial working version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.idea
+.project
+.DS_Store
+*.sublime*
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.swp
+*.swo
+node_modules
+dist
+*xunit.xml

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,24 @@
+{
+  "preset": "google",
+  "requireCurlyBraces": [
+     "do",
+     "try",
+     "catch"
+  ],
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "disallowSpacesInsideObjectBrackets": null,
+  "requireSpaceAfterLineComment": true,
+  "maximumLineLength": {
+     "value": 80,
+     "allowRegex": true
+  },
+  "validateJSDoc": {
+    "checkParamNames": false,
+    "checkRedundantParams": false,
+    "requireParamTypes": true
+  },
+  "excludeFiles": [
+    "node_modules/**",
+    "coverage/**"
+  ]
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+test/sandbox/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+"node": true,
+"camelcase" : true,
+"eqnull" : true,
+"indent": 2,
+"undef": true,
+"quotmark": "single",
+"newcap": true,
+"nonew": true,
+"sub": true,
+"laxcomma": true,
+"laxbreak": true,
+"globals": {
+  "after": true,
+  "afterEach": true,
+  "assert": true,
+  "before": true,
+  "beforeEach": true,
+  "describe": true,
+  "expect": true,
+  "it": true
+ }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,316 @@
+Copyright (c) 2013-2014 StrongLoop, Inc and other contributors.
+
+loopback-filter uses a 'dual license' model. Users may use loopback-filter under the terms of 
+the MIT license, or under the StrongLoop License. The text of both is included 
+below.
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+StrongLoop License
+
+You may obtain a copy of the License at
+
+    http://www.strongloop.com/license/
+
+STRONGLOOP SUBSCRIPTION AGREEMENT
+
+PLEASE READ THIS AGREEMENT CAREFULLY BEFORE YOU AGREE TO THESE TERMS.  IF YOU
+ARE ACTING ON BEHALF OF AN ENTITY, THEN YOU REPRESENT THAT YOU HAVE THE
+AUTHORITY TO ENTER INTO THIS AGREEMENT ON BEHALF OF THAT ENTITY.  IF YOU DO NOT
+AGREE TO THESE TERMS, YOU SHOULD NOT AGREE TO THE TERMS OF THIS AGREEMENT OR
+INSTALL OR USE THE SOFTWARE.
+This StrongLoop Subscription Agreement ("Agreement") is made by and between
+StrongLoop, Inc. ("StrongLoop") with its principal place of business at 107 S.
+B St, Suite 220, San Mateo, CA 94401 and the person or entity entering into this
+Agreement ("Customer").  The effective date ("Effective Date") of this Agreement
+is the date Customer agrees to these terms or installs or uses the Software (as
+defined below).  This Agreement applies to Customer's use of the Software but it
+shall be superseded by any signed agreement between you and StrongLoop
+concerning the Software.
+1. Subscriptions and Licenses.
+1.1 Subscriptions.  StrongLoop offers five different subscription levels to its
+customers, each as more particularly described on StrongLoop's website located
+at www.strongloop.com (the "StrongLoop Site"):  (1) Free; (2) Developer; (3)
+Professional; (4) Gold; and (5) Platinum.  The actual subscription level
+applicable to Customer (the "Subscription") will be specified in the purchase
+order that Customer issues to StrongLoop.  This Agreement applies to Customer
+regardless of the level of the Subscription selected by Customer and whether or
+not Customer upgrades or downgrades its Subscription.  StrongLoop hereby agrees
+to provide the services as described on the StrongLoop Site for each
+Subscription level during the term for which Customer has purchased the
+applicable Subscription, subject to Customer paying the fees applicable to the
+Subscription level purchased, if any (the "Subscription Fees").  StrongLoop may
+modify the services to be provided under any Subscription upon notice to
+Customer.
+1.2 License Grant.  Subject to the terms and conditions of this Agreement,
+StrongLoop grants to Customer, during the Subscription Term (as defined in
+Section 7.1 (Term and Termination) of this Agreement, a limited, non-exclusive,
+non-transferable right and license, to install and use the  StrongLoop Suite
+software (the "Software") and the documentation made available electronically as
+part of the Software (the "Documentation"), either of which may be modified
+during the Term (as defined in Section 7.1 below), solely for development,
+production and commercial purposes so long as Customer is using the Software to
+run only one process on a given operating system at a time.  This Agreement,
+including but not limited to the license and restrictions contained herein,
+apply to Customer regardless of whether Customer accesses the Software via
+download from the StrongLoop Site or through a third-party website or service,
+even if Customer acquired the Software prior to agreeing to this Agreement.
+1.3 License Restrictions.  Customer shall not itself, or through any parent,
+subsidiary, affiliate, agent or other third party:
+      1.3.1 sell, lease, license, distribute, sublicense or otherwise transfer
+      in whole or in part, any Software or the Documentation to a third party;
+      or
+      1.3.2 decompile, disassemble, translate, reverse engineer or otherwise
+      attempt to derive source code from the Software, in whole or in part, nor
+      shall Customer use any mechanical, electronic or other method to trace,
+      decompile, disassemble, or identify the source code of the Software or
+      encourage others to do so, except to the limited extent, if any, that
+      applicable law permits such acts notwithstanding any contractual
+      prohibitions, provided, however, before Customer exercises any rights that
+      Customer believes to be entitled to based on mandatory law, Customer shall
+      provide StrongLoop with thirty (30) days prior written notice and provide
+      all reasonably requested information to allow StrongLoop to assess
+      Customer's claim and, at StrongLoop's sole discretion, to provide
+      alternatives that reduce any adverse impact on StrongLoop's intellectual
+      property or other rights; or
+      1.3.3 allow access or permit use of the Software by any users other than
+      Customer's employees or authorized third-party contractors who are
+      providing services to Customer and agree in writing to abide by the terms
+      of this Agreement, provided further that Customer shall be liable for any
+      failure by such employees and third-party contractors to comply with the
+      terms of this Agreement and no usage restrictions, if any, shall be
+      exceeded; or
+      1.3.4 create, develop, license, install, use, or deploy any third party
+      software or services to circumvent or provide access, permissions or
+      rights which violate the license keys embedded within the Software; or
+      1.3.5 modify or create derivative works based upon the Software or
+      Documentation; or disclose the results of any benchmark test of the
+      Software to any third party without StrongLoop's prior written approval;
+      or
+      1.3.6 change any proprietary rights notices which appear in the Software
+      or Documentation; or
+      1.3.7 use the Software as part of a time sharing or service bureau
+      purposes or in any other resale capacity.
+1.4 Third-Party Software.  The Software may include individual certain software
+that is owned by third parties, including individual open source software
+components (the "Third-Party Software"), each of which has its own copyright and
+its own applicable license conditions.  Such third-party software is licensed to
+Customer under the terms of the applicable third-party licenses and/or copyright
+notices that can be found in the LICENSES file, the Documentation or other
+materials accompanying the Software, except that Sections 5 (Warranty
+Disclaimer) and 6 (Limitation of Liability) also govern Customer's use of the
+third-party software.  Customer agrees to comply with the terms and conditions
+of the relevant third-party software licenses.
+2. Support Services.  StrongLoop has no obligation to provide any support for
+the Software other than the support services specifically described on the
+StrongLoop Site for the Subscription level procured by Customer.  However,
+StrongLoop has endeavored to establish a community of users of the Software who
+have provided their own feedback, hints and advice regarding their experiences
+in using the Software.  You can find that community and user feedback on the
+StrongLoop Site.  The use of any information, content or other materials from,
+contained in or on the StrongLoop Site are subject to the StrongLoop website
+terms of use located here http://www.strongloop.com/terms-of-service.
+3. Confidentiality.  For purposes of this Agreement, "Confidential Information"
+means any and all information or proprietary materials (in every form and media)
+not generally known in the relevant trade or industry and which has been or is
+hereafter disclosed or made available by StrongLoop to Customer in connection
+with the transactions contemplated under this Agreement, including (i) all trade
+secrets, (ii) existing or contemplated Software, services, designs, technology,
+processes, technical data, engineering, techniques, methodologies and concepts
+and any related information, and (iii) information relating to business plans,
+sales or marketing methods and customer lists or requirements.  For a period of
+five (5) years from the date of disclosure of the applicable Confidential
+Information, Customer shall (i) hold the Confidential Information in trust and
+confidence and avoid the disclosure or release thereof to any other person or
+entity by using the same degree of care as it uses to avoid unauthorized use,
+disclosure, or dissemination of its own Confidential Information of a similar
+nature, but not less than reasonable care, and (ii) not use the Confidential
+Information for any purpose whatsoever except as expressly contemplated under
+this Agreement; provided that, to the extent the Confidential Information
+constitutes a trade secret under law, Customer agrees to protect such
+information for so long as it qualifies as a trade secret under applicable law.
+Customer shall disclose the Confidential Information only to those of its
+employees and contractors having a need to know such Confidential Information
+and shall take all reasonable precautions to ensure that such employees and
+contractors comply with the provisions of this Section.  The obligations of
+Customer under this Section shall not apply to information that Customer can
+demonstrate (i) was in its possession at the time of disclosure and without
+restriction as to confidentiality, (ii) at the time of disclosure is generally
+available to the public or after disclosure becomes generally available to the
+public through no breach of agreement or other wrongful act by Customer, (iii)
+has been received from a third party without restriction on disclosure and
+without breach of agreement by Customer, or (iv) is independently developed by
+Customer without regard to the Confidential Information.  In addition, Customer
+may disclose Confidential Information as required to comply with binding orders
+of governmental entities that have jurisdiction over it; provided that Customer
+gives StrongLoop reasonable written notice to allow StrongLoop to seek a
+protective order or other appropriate remedy, discloses only such Confidential
+Information as is required by the governmental entity, and uses commercially
+reasonable efforts to obtain confidential treatment for any Confidential
+Information disclosed.  Notwithstanding the above, Customer agrees that
+StrongLoop, its employees and agents shall be free to use and employ their
+general skills, know-how, and expertise, and to use, disclose, and employ any
+generalized ideas, concepts, know-how, methods, techniques or skills gained or
+learned during the Term or thereafter.
+4. Ownership.  StrongLoop shall retain all intellectual property and proprietary
+rights in the Software, Documentation, and related works, including but not
+limited to any derivative work of the foregoing and StrongLoop's licensors shall
+retain all intellectual property and proprietary rights in any Third-Party
+Software that may be provided with or as a part of the Software.  Customer shall
+do nothing inconsistent with StrongLoop's or its licensors' title to the
+Software and the intellectual property rights embodied therein, including, but
+not limited to, transferring, loaning, selling, assigning, pledging, or
+otherwise disposing, encumbering, or suffering a lien or encumbrance upon or
+against any interest in the Software.  The Software (including any Third-Party
+Software) contain copyrighted material, trade secrets and other proprietary
+material of StrongLoop and/or its licensors.
+5. Warranty Disclaimer.  THE SOFTWARE (INCLUDING ANY THIRD-PARTY SOFTWARE) AND
+DOCUMENTATION MADE AVAILABLE TO CUSTOMER ARE PROVIDED "AS-IS" AND STRONGLOOP,
+ON BEHALF OF ITSELF AND ITS LICENSORS, EXPRESSLY DISCLAIMS ALL WARRANTIES OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, TITLE,
+PERFORMANCE, AND ACCURACY AND ANY IMPLIED WARRANTIES ARISING FROM STATUTE,
+COURSE OF DEALING, COURSE OF PERFORMANCE, OR USAGE OF TRADE.  STRONGLOOP DOES
+NOT WARRANT THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR
+ERROR-FREE, THAT DEFECTS IN THE SOFTWARE WILL BE CORRECTED OR THAT THE SOFTWARE
+WILL PROVIDE OR ENSURE ANY PARTICULAR RESULTS OR OUTCOME.  NO ORAL OR WRITTEN
+INFORMATION OR ADVICE GIVEN BY STRONGLOOP OR ITS AUTHORIZED REPRESENTATIVES
+SHALL CREATE A WARRANTY OR IN ANY WAY INCREASE THE SCOPE OF THIS WARRANTY.
+STRONGLOOP IS NOT OBLIGATED TO PROVIDE CUSTOMER WITH UPGRADES TO THE SOFTWARE,
+BUT MAY ELECT TO DO SO IN ITS SOLE DISCRETION. SOME JURISDICTIONS DO NOT ALLOW
+THE EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT APPLY TO
+CUSTOMER.WITHOUT LIMITING THE GENERALITY OF THE FOREGOING DISCLAIMER, THE
+SOFTWARE AND DOCUMENTATION ARE NOT DESIGNED, MANUFACTURED OR INTENDED FOR USE IN
+THE PLANNING, CONSTRUCTION, MAINTENANCE, CONTROL, OR DIRECT OPERATION OF NUCLEAR
+FACILITIES, AIRCRAFT NAVIGATION, CONTROL OR COMMUNICATION SYSTEMS, WEAPONS
+SYSTEMS, OR DIRECT LIFE SUPPORT SYSTEMS.
+6. Limitation of Liability.
+      6.1 Exclusion of Liability.  IN NO EVENT WILL STRONGLOOP OR ITS LICENSORS
+      BE LIABLE UNDER THIS AGREEMENT FOR ANY INDIRECT, RELIANCE, PUNITIVE,
+      CONSEQUENTIAL, SPECIAL, EXEMPLARY, OR INCIDENTAL DAMAGES OF ANY KIND AND
+      HOWEVER CAUSED (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF
+      BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION AND
+      THE LIKE), EVEN IF STRONGLOOP HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+      DAMAGES.  CUSTOMER BEARS FULL RESPONSIBILITY FOR USE OF THE SOFTWARE AND
+      THE SUBSCRIPTION AND STRONGLOOP DOES NOT GUARANTEE THAT THE USE OF THE
+      SOFTWARE AND SUBSCRIPTION WILL ENSURE THAT CUSTOMER'S NETWORK WILL BE
+      AVAILABLE, SECURE, MONITORED OR PROTECTED AGAINST ANY DOWNTIME, DENIAL OF
+      SERVICE ATTACKS, SECUITY BREACHES, HACKERS AND THE LIKE.  IN NO EVENT WILL
+      STRONGLOOP'S CUMULATIVE LIABILITY FOR ANY DAMAGES, LOSSES AND CAUSES OF
+      ACTION (WHETHER IN CONTRACT, TORT, INCLUDING NEGLIGENCE, OR OTHERWISE)
+      ARISING OUT OF OR RELATED TO THIS AGREEMENT EXCEED THE GREATER OF ONE
+      HUNDRED DOLLARS (US$100) OR THE TOTAL SUBSCRIPTION FEES PAID BY CUSTOMER
+      TO STRONGLOOP IN THE TWELVE (12) MONTHS PRECEDING THE DATE THE CLAIM
+      ARISES.
+      6.2 Limitation of Damages.  IN NO EVENT WILL STRONGLOOP'S LICENSORS HAVE
+      ANY LIABILITY FOR ANY CLAIM ARISING IN CONNECTION WITH THIS AGREEMENT.
+      THE PROVISIONS OF THIS SECTION 6 ALLOCATE RISKS UNDER THIS AGREEMENT
+      BETWEEN CUSTOMER, STRONGLOOP AND STRONGLOOP'S SUPPLIERS.  THE FOREGOING
+      LIMITATIONS, EXCLUSIONS AND DISCLAIMERS APPLY TO THE MAXIMUM EXTENT
+      PERMITTED BY APPLICABLE LAW, EVEN IF ANY REMEDY FAILS IN ITS ESSENTIAL
+      PURPOSE.
+      6.3 Failure of Essential Purpose.  THE PARTIES AGREE THAT THESE
+      LIMITATIONS SHALL APPLY EVEN IF THIS AGREEMENT OR ANY LIMITED REMEDY
+      SPECIFIED HEREIN IS FOUND TO HAVE FAILED OF ITS ESSENTIAL PURPOSE.
+      6.4 Allocation of Risk.  The sections on limitation of liability and
+      disclaimer of warranties allocate the risks in the Agreement between the
+      parties.  This allocation is an essential element of the basis of the
+      bargain between the parties.
+7. Term and Termination.
+7.1 This Agreement shall commence on the Effective Date and continue for so long
+as Customer has a valid Subscription and is current on the payment of any
+Subscription Fees required to be paid for that Subscription (the "Subscription
+Term").  Either party may terminate this Agreement immediately upon written
+notice to the other party, and the Subscription and licenses granted hereunder
+automatically terminate upon the termination of this Agreement.  This Agreement
+will terminate immediately without notice from StrongLoop if Customer fails to
+comply with or otherwise breaches any provision of this Agreement.
+7.2 All Sections other than Section 1.1 (Subscriptions) and 1.2 (Licenses) shall
+survive the expiration or termination of this Agreement.
+8. Subscription Fees and Payments.  StrongLoop, Customer agrees to pay
+StrongLoop the Subscription Fees as described on the StrongLoop Site for the
+Subscription purchased unless a different amount has been agreed to in a
+separate agreement between Customer and StrongLoop.  In addition, Customer shall
+pay all sales, use, value added, withholding, excise taxes and other tax, duty,
+custom and similar fees levied upon the delivery or use of the Software and the
+Subscriptions described in this Agreement.  Fees shall be invoiced in full upon
+StrongLoop's acceptance of Customer's purchase order for the Subscription.  All
+invoices shall be paid in US dollars and are due upon receipt and shall be paid
+within thirty (30) days. Payments shall be made without right of set-off or
+chargeback. If Customer does not pay the invoices when due, StrongLoop may
+charge interest at one percent (1%) per month or the highest rate permitted by
+law, whichever is lower, on the unpaid balance from the original due date. If
+Customer fails to pay fees in accordance with this Section, StrongLoop may
+suspend fulfilling its obligations under this Agreement (including but not
+limited to suspending the services under the Subscription) until payment is
+received by StrongLoop.  If any applicable law requires Customer to withhold
+amounts from any payments to StrongLoop under this Agreement, (a) Customer shall
+effect such withholding, remit such amounts to the appropriate taxing
+authorities and promptly furnish StrongLoop with tax receipts evidencing the
+payments of such amounts and (b) the sum payable by Customer upon which the
+deduction or withholding is based shall be increased to the extent necessary to
+ensure that, after such deduction or withholding, StrongLoop receives and
+retains, free from liability for such deduction or withholding, a net amount
+equal to the amount StrongLoop would have received and retained absent the
+required deduction or withholding.
+9. General.
+9.1 Compliance with Laws.  Customer shall abide by all local, state, federal and
+international laws, rules, regulations and orders applying to Customer's use of
+the Software, including, without limitation, the laws and regulations of the
+United States that may restrict the export and re-export of certain commodities
+and technical data of United States origin, including the Software.  Customer
+agrees that it will not export or re-export the Software without the appropriate
+United States or foreign government licenses.
+9.2 Entire Agreement.  This Agreement constitutes the entire agreement between
+the parties concerning the subject matter hereof.  This Agreement supersedes all
+prior or contemporaneous discussions, proposals and agreements between the
+parties relating to the subject matter hereof.  No amendment, modification or
+waiver of any provision of this Agreement shall be effective unless in writing
+and signed by both parties.  Any additional or different terms on any purchase
+orders issued by Customer to StrongLoop shall not be binding on either party,
+are hereby rejected by StrongLoop and void.
+9.3 Severability.  If any provision of this Agreement is held to be invalid or
+unenforceable, the remaining portions shall remain in full force and effect and
+such provision shall be enforced to the maximum extent possible so as to effect
+the intent of the parties and shall be reformed to the extent necessary to make
+such provision valid and enforceable.
+9.4 Waiver.  No waiver of rights by either party may be implied from any actions
+or failures to enforce rights under this Agreement.
+9.5 Force Majeure.  Neither party shall be liable to the other for any delay or
+failure to perform due to causes beyond its reasonable control (excluding
+payment of monies due).
+9.6 No Third Party Beneficiaries.  Unless otherwise specifically stated, the
+terms of this Agreement are intended to be and are solely for the benefit of
+StrongLoop and Customer and do not create any right in favor of any third party.
+9.7 Governing Law and Jurisdiction.  This Agreement shall be governed by the
+laws of the State of California, without reference to the principles of
+conflicts of law.  The provisions of the Uniform Computerized Information
+Transaction Act and United Nations Convention on Contracts for the International
+Sale of Goods shall not apply to this Agreement.  The parties shall attempt to
+resolve any dispute related to this Agreement informally, initially through
+their respective management, and then by non-binding mediation in San Francisco
+County, California.  Any litigation related to this Agreement shall be brought
+in the state or federal courts located in San Francisco County, California, and
+only in those courts and each party irrevocably waives any objections to such
+venue.
+9.8 Notices.  All notices must be in writing and shall be effective three (3)
+days after the date sent to the other party's headquarters, Attention Chief
+Financial Officer.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # loopback-filter
+
+This module implements LoopBack style filtering.
+
+## Install
+
+```sh
+$ npm install loopback-filter
+```
+
+## Usage
+
+Below is a basic example using the module
+
+```js
+var data = [{foo: 'bar'}, {bat: 'baz'}, {foo: 'bar'}];
+var filter = {where: {foo: 'bar'}};
+var filtered = require('loopback-filter')(data, filter);
+console.log(filtered);
+```
+
+The output would be:
+
+```js
+[{foo: 'bar'}, {foo: 'bar'}]
+```
+
+## Docs
+
+[See the LoopBack docs](http://docs.strongloop.com/display/public/LB/Querying+data) for the filter syntax.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,287 @@
+var debug = require('debug')('loopback:filter');
+var geo = require('./lib/geo');
+
+module.exports = function filterNodes(nodes, filter) {
+  if (filter) {
+    debug('filter %j', filter);
+    // do we need some sorting?
+    if (filter.order) {
+      nodes = nodes.sort(sorting.bind(normalizeOrder(filter)));
+    }
+
+    var nearFilter = geo.nearFilter(filter.where);
+
+    // geo sorting
+    if (nearFilter) {
+      nodes = geo.filter(nodes, nearFilter);
+    }
+
+    // do we need some filtration?
+    if (filter.where) {
+      nodes = nodes ? nodes.filter(applyFilter(filter)) : nodes;
+    }
+
+    // field selection
+    if (filter.fields) {
+      nodes = nodes.map(selectFields(filter.fields));
+    }
+
+    // limit/skip
+    var skip = filter.skip || filter.offset || 0;
+    var limit = filter.limit || nodes.length;
+    nodes = nodes.slice(skip, skip + limit);
+  }
+
+  return nodes;
+};
+
+function applyFilter(filter) {
+  var where = filter.where;
+  if (typeof where === 'function') {
+    return where;
+  }
+  return function(obj) {
+    return matchesFilter(obj, filter);
+  };
+}
+
+function matchesFilter(obj, filter) {
+  var where = filter.where;
+  var pass = true;
+  var keys = Object.keys(where);
+  keys.forEach(function(key) {
+    if (key === 'and' || key === 'or') {
+      if (Array.isArray(where[key])) {
+        if (key === 'and') {
+          pass = where[key].every(function(cond) {
+            return applyFilter({where: cond})(obj);
+          });
+          return pass;
+        }
+        if (key === 'or') {
+          pass = where[key].some(function(cond) {
+            return applyFilter({where: cond})(obj);
+          });
+          return pass;
+        }
+      }
+    }
+    if (!test(where[key], getValue(obj, key))) {
+      pass = false;
+    }
+  });
+  return pass;
+}
+
+function toRegExp(pattern) {
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+  var regex = '';
+  // Escaping user input to be treated as a literal string within a regex
+  // https://developer.mozilla.org
+  // /en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+  // #Writing_a_Regular_Expression_Pattern
+  pattern = pattern.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+  for (var i = 0, n = pattern.length; i < n; i++) {
+    var char = pattern.charAt(i);
+    if (char === '\\') {
+      i++; // Skip to next char
+      if (i < n) {
+        regex += pattern.charAt(i);
+      }
+      continue;
+    } else if (char === '%') {
+      regex += '.*';
+    } else if (char === '_') {
+      regex += '.';
+    } else if (char === '.') {
+      regex += '\\.';
+    } else if (char === '*') {
+      regex += '\\*';
+    } else {
+      regex += char;
+    }
+  }
+  return regex;
+}
+
+function test(example, value) {
+  if (typeof value === 'string' && (example instanceof RegExp)) {
+    return value.match(example);
+  }
+  if (example === undefined) {
+    return undefined;
+  }
+
+  if (typeof example === 'object' && example !== null) {
+    // ignore geo near filter
+    if (example.near) {
+      return true;
+    }
+
+    if (example.inq) {
+      // if (!value) return false;
+      for (var i = 0; i < example.inq.length; i++) {
+        if (example.inq[i] == value) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    if ('neq' in example) {
+      return compare(example.neq, value) !== 0;
+    }
+
+    if ('between' in example) {
+      return (testInEquality({gte:example.between[0]}, value) &&
+               testInEquality({lte:example.between[1]}, value));
+    }
+
+    if (example.like || example.nlike) {
+
+      var like = example.like || example.nlike;
+      if (typeof like === 'string') {
+        like = toRegExp(like);
+      }
+      if (example.like) {
+        return !!new RegExp(like).test(value);
+      }
+
+      if (example.nlike) {
+        return !new RegExp(like).test(value);
+      }
+    }
+
+    if (testInEquality(example, value)) {
+      return true;
+    }
+  }
+  // not strict equality
+  return (example !== null ? example.toString() : example) == (value != null ?
+    value.toString() : value);
+}
+
+/**
+ * Compare two values
+ * @param {*} val1 The 1st value
+ * @param {*} val2 The 2nd value
+ * @returns {number} 0: =, positive: >, negative <
+ * @private
+ */
+function compare(val1, val2) {
+  if (val1 == null || val2 == null) {
+    // Either val1 or val2 is null or undefined
+    return val1 == val2 ? 0 : NaN;
+  }
+  if (typeof val1 === 'number') {
+    return val1 - val2;
+  }
+  if (typeof val1 === 'string') {
+    return (val1 > val2) ? 1 : ((val1 < val2) ? -1 : (val1 == val2) ? 0 : NaN);
+  }
+  if (typeof val1 === 'boolean') {
+    return val1 - val2;
+  }
+  if (val1 instanceof Date) {
+    var result = val1 - val2;
+    return result;
+  }
+  // Return NaN if we don't know how to compare
+  return (val1 == val2) ? 0 : NaN;
+}
+
+function testInEquality(example, val) {
+  if ('gt' in example) {
+    return compare(val, example.gt) > 0;
+  }
+  if ('gte' in example) {
+    return compare(val, example.gte) >= 0;
+  }
+  if ('lt' in example) {
+    return compare(val, example.lt) < 0;
+  }
+  if ('lte' in example) {
+    return compare(val, example.lte) <= 0;
+  }
+  return false;
+}
+
+function getValue(obj, path) {
+  if (obj == null) {
+    return undefined;
+  }
+  var keys = path.split('.');
+  var val = obj;
+  for (var i = 0, n = keys.length; i < n; i++) {
+    val = val[keys[i]];
+    if (val == null) {
+      return val;
+    }
+  }
+  return val;
+}
+
+function selectFields(fields) {
+  // map function
+  return function(obj) {
+    var result = {};
+    var key;
+
+    for (var i = 0; i < fields.length; i++) {
+      key = fields[i];
+
+      result[key] = obj[key];
+    }
+    return result;
+  };
+}
+
+function sorting(a, b) {
+  var undefinedA, undefinedB;
+
+  for (var i = 0, l = this.length; i < l; i++) {
+    var aVal = getValue(a, this[i].key);
+    var bVal = getValue(b, this[i].key);
+    undefinedB = bVal === undefined && aVal !== undefined;
+    undefinedA = aVal === undefined && bVal !== undefined;
+
+    if (undefinedB || aVal > bVal) {
+      return 1 * this[i].reverse;
+    } else if (undefinedA || aVal < bVal) {
+      return -1 * this[i].reverse;
+    }
+  }
+
+  return 0;
+}
+
+function normalizeOrder(filter) {
+  var orders = filter.order;
+
+  // transform into an array
+  if (typeof orders === 'string') {
+    if (filter.order.indexOf(',') > -1) {
+      orders = filter.order.split(/,\s*/);
+    } else {
+      orders = [filter.order];
+    }
+  }
+
+  orders.forEach(function(key, i) {
+    var reverse = 1;
+    console.log(key);
+    var m = key.match(/\s+(A|DE)SC$/i);
+    if (m) {
+      key = key.replace(/\s+(A|DE)SC/i, '');
+      if (m[1].toLowerCase() === 'de') reverse = -1;
+    } else {
+      var Ctor = SyntaxError || Error;
+      throw new Ctor('filter.order must includ ASC of DESC');
+    }
+    orders[i] = {'key': key, 'reverse': reverse};
+  });
+
+  return (filter.orders = orders);
+}

--- a/lib/geo.js
+++ b/lib/geo.js
@@ -1,0 +1,273 @@
+var assert = require('assert');
+
+/*!
+ * Get a near filter from a given where object. For connector use only.
+ */
+
+exports.nearFilter = function nearFilter(where) {
+  var result = false;
+
+  if (where && typeof where === 'object') {
+    Object.keys(where).forEach(function(key) {
+      var ex = where[key];
+
+      if (ex && ex.near) {
+        result = {
+          near: ex.near,
+          maxDistance: ex.maxDistance,
+          key: key
+        };
+      }
+    });
+  }
+
+  return result;
+};
+
+/*!
+ * Filter a set of objects using the given `nearFilter`.
+ */
+
+exports.filter = function(arr, filter) {
+  var origin = filter.near;
+  var max = filter.maxDistance > 0 ? filter.maxDistance : false;
+  var key = filter.key;
+
+  // create distance index
+  var distances = {};
+  var result = [];
+
+  arr.forEach(function(obj) {
+    var loc = obj[key];
+
+    // filter out objects without locations
+    if (!loc) return;
+
+    if (!(loc instanceof GeoPoint)) {
+      loc = new GeoPoint(loc);
+    }
+
+    if (typeof loc.lat !== 'number') return;
+    if (typeof loc.lng !== 'number') return;
+
+    var d = GeoPoint.distanceBetween(origin, loc);
+
+    if (max && d > max) {
+      // dont add
+    } else {
+      distances[obj.id] = d;
+      result.push(obj);
+    }
+  });
+
+  return result.sort(function(objA, objB) {
+    var a = objB[key];
+    var b = objB[key];
+
+    if (a && b) {
+      var da = distances[objA.id];
+      var db = distances[objB.id];
+
+      if (db === da) return 0;
+      return da > db ? 1 : -1;
+    } else {
+      return 0;
+    }
+  });
+};
+
+exports.GeoPoint = GeoPoint;
+
+/**
+ * The GeoPoint object represents a physical location.
+ *
+ * For example:
+ *
+ * ```js
+ * var loopback = require(‘loopback’);
+ * var here = new loopback.GeoPoint({lat: 10.32424, lng: 5.84978});
+ * ```
+ *
+ * Embed a latitude / longitude point in a model.
+ *
+ * ```js
+ * var CoffeeShop = loopback.createModel('coffee-shop', {
+ *   location: 'GeoPoint'
+ * });
+ * ```
+ *
+ * @class GeoPoint
+ * @property {Number} lat The latitude in degrees.
+ * @property {Number} lng The longitude in degrees.
+ *
+ * @options {Object} Options Object with two Number properties: lat and long.
+ * @property {Number} lat The latitude point in degrees. Range: -90 to 90.
+ * @property {Number} lng The longitude point in degrees. Range: -180 to 180.
+ *
+ * @options {Array} Options Array with two Number entries: [lat,long].
+ * @property {Number} lat The latitude point in degrees. Range: -90 to 90.
+ * @property {Number} lng The longitude point in degrees. Range: -180 to 180.
+ */
+
+function GeoPoint(data) {
+  if (!(this instanceof GeoPoint)) {
+    return new GeoPoint(data);
+  }
+
+  if (arguments.length === 2) {
+    data = {
+      lat: arguments[0],
+      lng: arguments[1]
+    };
+  }
+
+  assert(Array.isArray(data) ||
+    typeof data === 'object' || typeof data === 'string',
+    'must provide valid geo-coordinates array [lat, lng] or object' +
+    ' or a "lat, lng" string');
+
+  if (typeof data === 'string') {
+    data = data.split(/,\s*/);
+    assert(data.length === 2,
+      'must provide a string "lat,lng" creating a GeoPoint with a string');
+  }
+
+  if (Array.isArray(data)) {
+    data = {
+      lat: Number(data[0]),
+      lng: Number(data[1])
+    };
+  } else {
+    data.lng = Number(data.lng);
+    data.lat = Number(data.lat);
+  }
+
+  assert(typeof data === 'object',
+    'must provide a lat and lng object when creating a GeoPoint');
+  assert(typeof data.lat === 'number' && !isNaN(data.lat),
+    'lat must be a number when creating a GeoPoint');
+  assert(typeof data.lng === 'number' && !isNaN(data.lng),
+    'lng must be a number when creating a GeoPoint');
+  assert(data.lng <= 180, 'lng must be <= 180');
+  assert(data.lng >= -180, 'lng must be >= -180');
+  assert(data.lat <= 90, 'lat must be <= 90');
+  assert(data.lat >= -90, 'lat must be >= -90');
+
+  this.lat = data.lat;
+  this.lng = data.lng;
+}
+
+/**
+ * Determine the spherical distance between two GeoPoints.
+ *
+ * @param  {GeoPoint} pointA Point A
+ * @param  {GeoPoint} pointB Point B
+ * @options  {Object} options Options object with one key, 'type'.  See below.
+ * @property {String} type Unit of measurement, one of:
+ *
+ * - `miles` (default)
+ * - `radians`
+ * - `kilometers`
+ * - `meters`
+ * - `miles`
+ * - `feet`
+ * - `degrees`
+ */
+
+GeoPoint.distanceBetween = function distanceBetween(a, b, options) {
+  if (!(a instanceof GeoPoint)) {
+    a = new GeoPoint(a);
+  }
+  if (!(b instanceof GeoPoint)) {
+    b = new GeoPoint(b);
+  }
+
+  var x1 = a.lat;
+  var y1 = a.lng;
+
+  var x2 = b.lat;
+  var y2 = b.lng;
+
+  return geoDistance(x1, y1, x2, y2, options);
+};
+
+/**
+ * Determine the spherical distance to the given point.
+ * Example:
+ * ```js
+ * var loopback = require(‘loopback’);
+ *
+ * var here = new loopback.GeoPoint({lat: 10, lng: 10});
+ * var there = new loopback.GeoPoint({lat: 5, lng: 5});
+ *
+ * loopback.GeoPoint.distanceBetween(here, there, {type: 'miles'}) // 438
+ * ```
+ * @param {Object} point GeoPoint object to which to measure distance.
+ * @options  {Object} options Options object with one key, 'type'.  See below.
+ * @property {String} type Unit of measurement, one of:
+ *
+ * - `miles` (default)
+ * - `radians`
+ * - `kilometers`
+ * - `meters`
+ * - `miles`
+ * - `feet`
+ * - `degrees`
+ */
+
+GeoPoint.prototype.distanceTo = function(point, options) {
+  return GeoPoint.distanceBetween(this, point, options);
+};
+
+/**
+ * Simple serialization.
+ */
+
+GeoPoint.prototype.toString = function() {
+  return this.lat + ',' + this.lng;
+};
+
+/**
+ * @property {Number} DEG2RAD - Factor to convert degrees to radians.
+ * @property {Number} RAD2DEG - Factor to convert radians to degrees.
+ * @property {Object} EARTH_RADIUS - Radius of the earth.
+*/
+
+// factor to convert degrees to radians
+var DEG2RAD = 0.01745329252;
+
+// factor to convert radians degrees to degrees
+var RAD2DEG = 57.29577951308;
+
+// radius of the earth
+var EARTH_RADIUS = {
+  kilometers: 6370.99056,
+  meters: 6370990.56,
+  miles: 3958.75,
+  feet: 20902200,
+  radians: 1,
+  degrees: RAD2DEG
+};
+
+function geoDistance(x1, y1, x2, y2, options) {
+
+  var type = (options && options.type) || 'miles';
+
+  // Convert to radians
+  x1 = x1 * DEG2RAD;
+  y1 = y1 * DEG2RAD;
+  x2 = x2 * DEG2RAD;
+  y2 = y2 * DEG2RAD;
+
+  // use the haversine formula to calculate distance
+  // for any 2 points on a sphere.
+  // ref http://en.wikipedia.org/wiki/Haversine_formula
+  var haversine = function(a) {
+    return Math.pow(Math.sin(a / 2.0), 2);
+  };
+
+  var f = Math.sqrt(haversine(x2 - x1) +
+    Math.cos(x2) * Math.cos(x1) * haversine(y2 - y1));
+
+  return 2 * Math.asin(f) * EARTH_RADIUS[type];
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "loopback-filter",
+  "version": "0.1.0",
+  "description": "Apply LoopBack filters to Arrays",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "debug": "^2.2.0"
+  },
+  "devDependencies": {
+    "jscs": "^1.13.1",
+    "jshint": "^2.8.0",
+    "mocha": "^2.2.5",
+    "should": "^6.0.3"
+  },
+  "scripts": {
+    "pretest": "jscs . && jshint .",
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-filter.git"
+  },
+  "keywords": [
+    "LoopBack",
+    "filter",
+    "sort",
+    "sorting",
+    "query"
+  ],
+  "author": "Ritchie Martori",
+  "license": {
+    "name": "Dual MIT/StrongLoop",
+    "url": "https://github.com/strongloop/loopback/blob/master/LICENSE"
+  },
+  "bugs": {
+    "url": "https://github.com/strongloop/loopback-filter/issues"
+  },
+  "homepage": "https://github.com/strongloop/loopback-filter"
+}

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -1,0 +1,277 @@
+var assert = require('assert');
+var should = require('should');
+var filter = require('../');
+var users;
+
+describe('filter', function() {
+  before(seed);
+
+  it('should allow to find using like', function(done) {
+    applyFilter({where: {name: {like: '%St%'}}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 2);
+      done();
+    });
+  });
+
+  it('should support like for no match', function(done) {
+    applyFilter({where: {name: {like: 'M%XY'}}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 0);
+      done();
+    });
+  });
+
+  it('should allow to find using nlike', function(done) {
+    applyFilter({where: {name: {nlike: '%St%'}}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 4);
+      done();
+    });
+  });
+
+  it('should support nlike for no match', function(done) {
+    applyFilter({where: {name: {nlike: 'M%XY'}}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 6);
+      done();
+    });
+  });
+
+  // input validation
+  describe.skip('invalid input', function() {
+    it(
+      'should throw if the like value is not string or regexp',
+      function(done) {
+        applyFilter({where: {name: {like: 123}}}, function(err, users) {
+          should.exist(err);
+          done();
+        });
+      }
+    );
+
+    it(
+      'should throw if the nlike value is not string or regexp',
+      function(done) {
+        applyFilter({where: {name: {nlike: 123}}}, function(err, users) {
+          should.exist(err);
+          done();
+        });
+      }
+    );
+
+    it('should throw if the inq value is not an array', function(done) {
+      applyFilter({where: {name: {inq: '12'}}}, function(err, users) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should throw if the nin value is not an array', function(done) {
+      applyFilter({where: {name: {nin: '12'}}}, function(err, users) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should throw if the between value is not an array', function(done) {
+      applyFilter({where: {name: {between: '12'}}}, function(err, users) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it(
+      'should throw if the between value is not an array of length 2',
+      function(done) {
+        applyFilter({where: {name: {between: ['12']}}}, function(err, users) {
+          should.exist(err);
+          done();
+        });
+      }
+    );
+  });
+
+  it('should successfully extract 5 users from the db', function(done) {
+    applyFilter({where: {seq: {between: [1, 5]}}}, function(err, users) {
+      should(users.length).be.equal(5);
+      done();
+    });
+  });
+
+  it('should successfully extract 1 user (Lennon) from the db', function(done) {
+    applyFilter({
+      where: {birthday: {between: [new Date(1970, 0), new Date(1990, 0)]}}
+    },
+    function(err, users) {
+      should(users.length).be.equal(1);
+      should(users[0].name).be.equal('John Lennon');
+      done();
+    });
+  });
+
+  it('should successfully extract 2 users from the db', function(done) {
+    applyFilter({
+      where: {birthday: {between: [new Date(1940, 0), new Date(1990, 0)]}}
+    },
+    function(err, users) {
+      should(users.length).be.equal(2);
+      done();
+    });
+  });
+
+  it('should successfully extract 0 user from the db', function(done) {
+    applyFilter({where: {birthday: {between: [new Date(1990, 0), Date.now()]}}},
+              function(err, users) {
+      should(users.length).be.equal(0);
+      done();
+    });
+  });
+
+  it('should support order with multiple fields', function(done) {
+    applyFilter({order: 'vip ASC, seq DESC'}, function(err, users) {
+      should.not.exist(err);
+      users[0].seq.should.be.eql(4);
+      users[1].seq.should.be.eql(3);
+      done();
+    });
+  });
+
+  it('should sort undefined values to the end when ordered DESC',
+  function(done) {
+    applyFilter({order: 'vip ASC, order DESC'}, function(err, users) {
+      should.not.exist(err);
+
+      users[4].seq.should.be.eql(1);
+      users[5].seq.should.be.eql(0);
+      done();
+    });
+  });
+
+  it('should throw if order has wrong direction', function(done) {
+    applyFilter({order: 'seq ABC'}, function(err, users) {
+      should.exist(err);
+      done();
+    });
+  });
+
+  it('should support neq operator for number', function(done) {
+    applyFilter({where: {seq: {neq: 4}}}, function(err, users) {
+      should.not.exist(err);
+      users.length.should.be.equal(5);
+      for (var i = 0; i < users.length; i++) {
+        users[i].seq.should.not.be.equal(4);
+      }
+      done();
+    });
+  });
+
+  it('should support neq operator for string', function(done) {
+    applyFilter({where: {role: {neq: 'lead'}}}, function(err, users) {
+      should.not.exist(err);
+      users.length.should.be.equal(4);
+      for (var i = 0; i < users.length; i++) {
+        if (users[i].role) {
+          users[i].role.not.be.equal('lead');
+        }
+      }
+      done();
+    });
+  });
+
+  it('should support neq operator for null', function(done) {
+    applyFilter({where: {role: {neq: null}}}, function(err, users) {
+      should.not.exist(err);
+      users.length.should.be.equal(2);
+      for (var i = 0; i < users.length; i++) {
+        should.exist(users[i].role);
+      }
+      done();
+    });
+  });
+
+  it('should support nested property in query', function(done) {
+    applyFilter({where: {'address.city': 'San Jose'}}, function(err, users) {
+      should.not.exist(err);
+      users.length.should.be.equal(1);
+      for (var i = 0; i < users.length; i++) {
+        users[i].address.city.should.be.eql('San Jose');
+      }
+      done();
+    });
+  });
+
+  it('should support nested property with gt in query', function(done) {
+    applyFilter({where: {'address.city': {gt: 'San'}}}, function(err, users) {
+      should.not.exist(err);
+      users.length.should.be.equal(2);
+      for (var i = 0; i < users.length; i++) {
+        users[i].address.state.should.be.eql('CA');
+      }
+      done();
+    });
+  });
+
+  it('should support nested property for order in query', function(done) {
+    applyFilter({where: {'address.state': 'CA'}, order: 'address.city DESC'},
+      function(err, users) {
+        should.not.exist(err);
+        users.length.should.be.equal(2);
+        users[0].address.city.should.be.eql('San Mateo');
+        users[1].address.city.should.be.eql('San Jose');
+        done();
+      });
+  });
+});
+
+// this weird function allows us to
+// re-use the tests from juggler
+function applyFilter(filterObj, cb) {
+  var result;
+
+  try {
+    result = filter(users, filterObj);
+  } catch (e) {
+    return cb(e);
+  }
+
+  cb(null, result);
+}
+
+function seed() {
+  users = [
+    {
+      seq: 0,
+      name: 'John Lennon',
+      email: 'john@b3atl3s.co.uk',
+      role: 'lead',
+      birthday: new Date('1980-12-08'),
+      vip: true,
+      address: {
+        street: '123 A St',
+        city: 'San Jose',
+        state: 'CA',
+        zipCode: '95131'
+      }
+    },
+    {
+      seq: 1,
+      name: 'Paul McCartney',
+      email: 'paul@b3atl3s.co.uk',
+      role: 'lead',
+      birthday: new Date('1942-06-18'),
+      order: 1,
+      vip: true,
+      address: {
+        street: '456 B St',
+        city: 'San Mateo',
+        state: 'CA',
+        zipCode: '94065'
+      }
+    },
+    {seq: 2, name: 'George Harrison', order: 5, vip: false},
+    {seq: 3, name: 'Ringo Starr', order: 6, vip: false},
+    {seq: 4, name: 'Pete Best', order: 4},
+    {seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true}
+  ];
+}


### PR DESCRIPTION
This is an extraction of the loopback filter mechanism from the juggler's memory connector. It supports the suite of tests from the memory connector. Specifically:
- `where`
- `limit`
- `skip` (offset)
- `fields`

**It does not support `include` or input validation.**

/to @raymondfeng 
/cc @bajtos @fabien

**Basic Example** (could use some ideas for better apis)

``` js
var data = [{foo: 'bar'}, {bat: 'baz'}, {foo: 'bar'}];
var filter = {where: {foo: 'bar'}};
var filtered = require('loopback-filter')(data, filter);
```
