### PR TITLE
Add tests for 'and' and 'or' filters

### DIFF
--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -43,6 +43,30 @@ describe('filter', function() {
     });
   });
 
+  it('should allow to find using an \'and\' filter ', function(done) {
+    var andFilter = [
+      {vip: true},
+      {role: 'lead'},
+    ];
+    applyFilter({where: {and: andFilter}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 2);
+      done();
+    });
+  });
+
+  it('should allow to find using an \'or\' filter ', function(done) {
+    var orFilter = [
+      {name: 'John Lennon'},
+      {name: 'Paul McCartney'},
+    ];
+    applyFilter({where: {or: orFilter}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 2);
+      done();
+    });
+  });
+
   // input validation
   describe.skip('invalid input', function() {
     it(


### PR DESCRIPTION
### Description

There were no test for `and` and `or` queries and it took me a while to get the right syntax so I figured I'd add them.

~Also added a script to run the test in watch mode.~

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
