### PR TITLE
Implement like and nlike insensitive filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,11 +175,11 @@ function test(example, value) {
         like = toRegExp(like);
       }
       if (example.like) {
-        return new RegExp(like).test(value);
+        return new RegExp(like, example.options).test(value);
       }
 
       if (example.nlike) {
-        return !new RegExp(like).test(value);
+        return !new RegExp(like, example.options).test(value);
       }
     }
 

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -20,6 +20,14 @@ describe('filter', function() {
     });
   });
 
+  it('should allow to find using like with options', function(done) {
+    applyFilter({where: {name: {like: '%St%', options: 'i'}}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 3);
+      done();
+    });
+  });
+
   it('should support like for no match', function(done) {
     applyFilter({where: {name: {like: 'M%XY'}}}, function(err, users) {
       should.not.exist(err);
@@ -32,6 +40,14 @@ describe('filter', function() {
     applyFilter({where: {name: {nlike: '%St%'}}}, function(err, users) {
       should.not.exist(err);
       users.should.have.property('length', 4);
+      done();
+    });
+  });
+
+  it('should allow to find using nlike with options', function(done) {
+    applyFilter({where: {name: {nlike: '%St%', options: 'i'}}}, function(err, users) {
+      should.not.exist(err);
+      users.should.have.property('length', 3);
       done();
     });
   });


### PR DESCRIPTION
### Description
Implemented insensitive filtering using 'options' flag. Added two tests for the filter.

Usage:
Via the REST API:

`?filter={"where":{"title":{"like":"someth.*","options":"i"}}}`

Official LB documentation: 
LB2 [http://loopback.io/doc/en/lb2/Where-filter.html#like-and-nlike-insensitive]
LB3 [http://loopback.io/doc/en/lb3/Where-filter.html#like-and-nlike-insensitive]

#### Related issues

No related issues.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
